### PR TITLE
Improved user contribution table colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -222,14 +222,14 @@ path.js-diff-placeholder {
     background: rgba(0,0,0,0.2);
 }
 /* Profile Contributions */
-rect.day:not([data-count="0"]), ul.legend {
+rect.day:not([data-count="0"]), ul.legend:not(:first-of-type) {
     filter: invert(100%) hue-rotate(180deg);
 }
 rect.day[data-count="0"] {
     fill: var(--bg1) !important;
 }
-ul.legend li:nth-child(1) {
-    background: #dcdcdc !important;
+ul.legend li:first-of-type {
+    background: var(--bg1) !important;
 }
 
 /* CODE */

--- a/style.css
+++ b/style.css
@@ -221,7 +221,16 @@ path.js-diff-placeholder {
 .ellipsis-expander, .hidden-text-expander a {
     background: rgba(0,0,0,0.2);
 }
-
+/* Profile Contributions */
+rect.day:not([data-count="0"]), ul.legend {
+    filter: invert(100%) hue-rotate(180deg);
+}
+rect.day[data-count="0"] {
+    fill: var(--bg1) !important;
+}
+ul.legend li:nth-child(1) {
+    background: #dcdcdc !important;
+}
 
 /* CODE */
 .pl-s .pl-s1, .pl-smi {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/38524171/73760655-41bc8700-4733-11ea-8e19-cd6d34564eb5.png)

After:
![image](https://user-images.githubusercontent.com/38524171/73760589-2cdff380-4733-11ea-8036-d8bd7ec1c05f.png)

This should work across all themes. Filters invert current colors and adjust hue so that only brightness would be affected.

Tested on Stylus 1.5.6 on Firefox 72.0.2