### PR TITLE
Fixed issue with new notification read/archived inbox

### DIFF
--- a/material-github.user.css
+++ b/material-github.user.css
@@ -140,6 +140,10 @@
 		--color-verified-badge-text:            #2cbe87;
 		--color-underlinenav-counter-text:      var(--text7);
 		
+		/* Notification System */
+		--color-notifications-row-bg:			var(--bg5);
+		--color-notifications-row-read-bg: 		var(--bg4);
+
 		/* OTHER */
 		--color-auto-gray-8:                    var(--text5);
 		--color-auto-gray-9:                    var(--text7);
@@ -607,16 +611,9 @@
 		color: rgba(255, 255, 255, calc(0.4 * /*[[text_brightness]]*/)) !important;
 		color: var(--text1) !important;
 	}
-	.notifications-list-item.notification-unread {
-		background-color: var(--bg5) !important;
-	}
 	.notifications-list-item.notification-unread .notification-list-item-link {
 		color: rgba(255, 255, 255, calc(0.9 * /*[[text_brightness]]*/))!important;
 		color: var(--text11) !important;
-	}
-	.notifications-list-item.notification-read,
-	.notifications-list-item.notification-archived {
-		background-color: var(--bg4) !important;
 	}
 	.notifications-list-item:hover {
 		background-color: var(--bg6)!important;
@@ -633,9 +630,6 @@
 	.notifications-list-item:hover .notification-list-item-actions .btn:hover {
 		color: rgb(255, 255, 255)!important;
 		background-color: var(--selected)!important;
-	}
-	.notifications-v2 .notification-navigation {
-		background-color: var(--bg3)!important;
 	}
 	.notification-navigation .notification-configure-filters:hover .octicon {
 		color: var(--selected)!important;

--- a/material-github.user.css
+++ b/material-github.user.css
@@ -1,6 +1,6 @@
 /* ==UserStyle==
 @name         Material Dark GitHub
-@version      4.0.2
+@version      4.0.3
 @description  A Material Dark theme for GitHub
 @namespace    CharlieEtienne
 @author       CharlieEtienne

--- a/material-github.user.css
+++ b/material-github.user.css
@@ -608,11 +608,15 @@
 		color: var(--text1) !important;
 	}
 	.notifications-list-item.notification-unread {
-		background-color: var(--bg5);
+		background-color: var(--bg5) !important;
 	}
 	.notifications-list-item.notification-unread .notification-list-item-link {
 		color: rgba(255, 255, 255, calc(0.9 * /*[[text_brightness]]*/))!important;
 		color: var(--text11) !important;
+	}
+	.notifications-list-item.notification-read,
+	.notifications-list-item.notification-archived {
+		background-color: var(--bg4) !important;
 	}
 	.notifications-list-item:hover {
 		background-color: var(--bg6)!important;


### PR DESCRIPTION
A new notification handling has been introduced where style for unread was marked !important and -read & -archived where added with var(--color-notifications-row-read-bg) !important.
If --bg4 is the correct color can be discussed, I personally like it that way:
- bg5 is read
- bg3 is background of the site and should not be used imho
- bg2 would also be an option maybe
- bg1 is same color as header and should not be used imho