### PR TITLE
Fixed readability of notification filter search warning

### DIFF
--- a/material-github.user.css
+++ b/material-github.user.css
@@ -1,6 +1,6 @@
 /* ==UserStyle==
 @name         Material Dark GitHub
-@version      4.0.2
+@version      4.0.5
 @description  A Material Dark theme for GitHub
 @namespace    CharlieEtienne
 @author       CharlieEtienne

--- a/material-github.user.css
+++ b/material-github.user.css
@@ -644,6 +644,9 @@
 		color: rgba(255,255,255,calc(0.9 * /*[[text_brightness]]*/))!important;
 		color: var(--text11) !important;
 	}
+	.js-notification-search-warning-container {
+		color: var(--text7) !important;
+	}
 	.card-filter-autocomplete-dropdown .navigation-focus, .card-filter-autocomplete-dropdown [aria-selected=true] {
 		background-color: var(--selected2);
 	}


### PR DESCRIPTION
Fixed a readability issue with the warning text for not supported search filters in notifications:

Before:
![grafik](https://user-images.githubusercontent.com/1161223/99739588-5fde5280-2acd-11eb-83c5-83eeeec6438d.png)
Now:
![grafik](https://user-images.githubusercontent.com/1161223/99739592-64a30680-2acd-11eb-846d-1812d33817e2.png)
