### PR TITLE
Make issue state text colours more visible

### DIFF
--- a/material-github.user.css
+++ b/material-github.user.css
@@ -1020,9 +1020,11 @@
 		color: #cb244b !important;
 	}
 	.bg-green, .State--green {
+		color: #d3d3d3 !important
 		background: #2cbe87 !important;
 	}
 	.bg-red, .State--red {
+		color: #d3d3d3 !important
 		background: #cb244b !important;
 	}
 	.summary-stats li, .summary-stats li .num, ul.summary-stats li a,.diffstat-summary {

--- a/material-github.user.css
+++ b/material-github.user.css
@@ -1020,11 +1020,11 @@
 		color: #cb244b !important;
 	}
 	.bg-green, .State--green {
-		color: #d3d3d3 !important
+		color: var(--text11) !important
 		background: #2cbe87 !important;
 	}
 	.bg-red, .State--red {
-		color: #d3d3d3 !important
+		color: var(--text11) !important
 		background: #cb244b !important;
 	}
 	.summary-stats li, .summary-stats li .num, ul.summary-stats li a,.diffstat-summary {


### PR DESCRIPTION
# Before:
![image](https://user-images.githubusercontent.com/6967592/104754722-76adc800-5751-11eb-88d0-a7e5f2372b17.png)
![image](https://user-images.githubusercontent.com/6967592/104754742-7d3c3f80-5751-11eb-9ca0-4b17b337a579.png)

# After:
![image](https://user-images.githubusercontent.com/6967592/104754935-b4125580-5751-11eb-9a9a-57f9237f6a58.png)
![image](https://user-images.githubusercontent.com/6967592/104754955-bb396380-5751-11eb-9ddf-2ba50f3a9954.png)


It might not be perfect, but I decided to make them both the same colour.  Maybe black would be better, but I think that's too different to all other text