### PR TITLE
Fixed Contribution Activity using the default bg

### DIFF
--- a/material-github.user.css
+++ b/material-github.user.css
@@ -1,6 +1,6 @@
 /* ==UserStyle==
 @name         Material Dark GitHub
-@version      4.0.6
+@version      4.0.7
 @description  A Material Dark theme for GitHub
 @namespace    CharlieEtienne
 @author       CharlieEtienne
@@ -1207,6 +1207,14 @@
 	.CheckStep-header:hover, .CheckStep[open] .CheckStep-header, .CheckStep-line{
 		--color-auto-gray-8: var(--bg5);
 		--color-auto-gray-9: var(--bg3);
+	}
+	
+	.js-profile-timeline-year-list {
+		background-color: var(--bg3) !important;
+	}
+	
+	.contribution-activity-listing h3 > span {
+		background-color: var(--bg3) !important;
 	}
 }
 


### PR DESCRIPTION
In the profile's Contribution Activity tab, the _month_ and _year_ sections were using the darker, default background color.
I also changed the version from 4.0.6 -> 4.0.7.

### Before
![Before](https://i.gyazo.com/d6f3ac843654714fc2cafa838bcde5d1.png)

### After
![](https://i.gyazo.com/838d71e79f317753c152c099f5572244.png)


